### PR TITLE
Add `update_tag.yml`

### DIFF
--- a/.github/workflows/update_tag.yml
+++ b/.github/workflows/update_tag.yml
@@ -1,0 +1,13 @@
+name: Update Major Version Tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  update-majorver:
+    name: Update Major Version Tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nowactions/update-majorver@v1


### PR DESCRIPTION
Once this is merged, I'll update the [`v1` release](https://github.com/OpenAstronomy/build-python-dist/releases/tag/v1) be have tag and name `v1.0.0`. That should then trigger this workflow to run and create a new `v1` tag at the same commit as `v1.0.0`.

This `update_tag.yml` workflow is identical to the one in `github-actions-workflows`.