### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This will also run on existing forks but apparently you can stop the updates by recreating the fork https://github.com/dependabot/dependabot-core/issues/2804 Since there are only 4 forks this shouldn't be an issue.