### PR TITLE
TST: add a job without dependency groups

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -31,3 +31,16 @@ jobs:
           test_groups: test
           test_extras: recommended
           test_command: pytest --pyargs test_package
+
+  build_no_groups:
+    name: Test action (default, no groups)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - id: build
+        uses: ./
+        with:
+          pure_python_wheel: true
+          test_extras: recommended
+          test_command: ''


### PR DESCRIPTION
Following failed downstream integration in https://github.com/OpenAstronomy/github-actions-workflows/pull/286, follow up to #21