### PR TITLE
BUG: fix invalid parsing for default `test_groups=''`

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -31,3 +31,16 @@ jobs:
           test_groups: test
           test_extras: recommended
           test_command: pytest --pyargs test_package
+
+  build_no_groups:
+    name: Test action (default, no groups)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - id: build
+        uses: ./
+        with:
+          pure_python_wheel: true
+          test_extras: recommended
+          test_command: python -c 'import test_package'

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,7 @@ runs:
     shell: bash
     run: |
       echo "group_flags=$( python -c "print(' '.join(f'--group {g.strip()}' for g in '${{ inputs.test_groups }}'.split(',')))" ) " >> "$GITHUB_ENV"
+    if: ${{ inputs.test_groups != '' }}
 
   - name: Test source distribution
     shell: bash


### PR DESCRIPTION
Following failed downstream integration in https://github.com/OpenAstronomy/github-actions-workflows/pull/286, follow up to #21
(redo #22)